### PR TITLE
Added User to migrations so they can successfully run on a fresh database

### DIFF
--- a/db/migrate/20130705080234_add_position_to_users.rb
+++ b/db/migrate/20130705080234_add_position_to_users.rb
@@ -1,4 +1,6 @@
 class AddPositionToUsers < ActiveRecord::Migration
+  class User < ActiveRecord::Base; end
+
   def change
     add_column :users, :position, :integer
 

--- a/db/migrate/20130815083711_split_into_players_and_users.rb
+++ b/db/migrate/20130815083711_split_into_players_and_users.rb
@@ -1,4 +1,6 @@
 class SplitIntoPlayersAndUsers < ActiveRecord::Migration
+  class User < ActiveRecord::Base; end
+
   def self.up
     rename_table :users, :players
     create_table :users do |t|

--- a/db/migrate/20130816000000_add_timestamps.rb
+++ b/db/migrate/20130816000000_add_timestamps.rb
@@ -1,4 +1,6 @@
 class AddTimestamps < ActiveRecord::Migration
+  class User < ActiveRecord::Base; end
+
   START_OF_TIME = Time.parse('2013-07-20 00:00:00')
 
   def change


### PR DESCRIPTION
The migrations were referring to a User model that does not exist, and so wouldn't run on a freshly created database
