### PR TITLE
Make results page more performant

### DIFF
--- a/app/helpers/players_helper.rb
+++ b/app/helpers/players_helper.rb
@@ -4,7 +4,7 @@ module PlayersHelper
   end
 
   def sparkline_data_for(player)
-    recorded_values = player.results.in_order.map(&:previous_state).map{|state| state['elo_ratings'].fetch(player.id){ nil } }
+    recorded_values = player.results.in_order.last(50).map(&:previous_state).map{|state| state['elo_ratings'].fetch(player.id){ nil } }
     values = recorded_values + [player.elo_rating]
     values.map{|v| v ? v - sparkline_central_value : 0 }.join(',')
   end


### PR DESCRIPTION
I couldn't help notice that the iPad struggles to render the results page, and occasionally doesn't show the graphs at all. I'm making an assumption that this is because it's struggling to render the spark lines data for each player because there is so much data there now.

To handle this, I've set a limit on the spark lines data to only include the last 50 results.
