### PR TITLE
Results page pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'pg'
 gem 'figaro'
 gem 'newrelic_rpm'
 gem 'font-awesome-sass'
+gem 'kaminari'
 
 group :development, :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     json (1.8.0)
     jwt (0.1.6)
       multi_json (>= 1.0)
+    kaminari (0.15.1)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     launchy (2.2.0)
       addressable (~> 2.3)
     mail (2.5.4)
@@ -74,7 +77,7 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.5.1)
     minitest (4.7.5)
-    multi_json (1.8.2)
+    multi_json (1.8.4)
     multipart-post (1.2.0)
     newrelic_rpm (3.6.7.159)
     nokogiri (1.6.0)
@@ -164,6 +167,7 @@ DEPENDENCIES
   font-awesome-sass
   jbuilder (~> 1.2)
   jquery-rails
+  kaminari
   launchy
   newrelic_rpm
   omniauth

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -72,3 +72,16 @@ body {
     }
   }
 }
+.pagination {
+  text-align: right;
+  > * {
+    display: inline-block;
+    min-width: 20px;
+    padding: 0 2px;
+    text-align: center;
+  }
+  a {
+    color: black;
+    text-decoration: none;
+  }
+}

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -2,7 +2,7 @@ class ResultsController < ApplicationController
   before_action :authenticate, only: [:create, :undo, :destroy]
 
   def index
-    @results = Result.latest_first
+    @results = Result.latest_first.page(params[:page]).per(params[:per_page])
   end
 
   def create

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -3,3 +3,4 @@
     <li><%= result.winner.name %> beat <%= result.loser.name %></li>
   <% end %>
 </ol>
+<%= paginate @results, remote: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,11 @@ en:
 
   result:
     summary: "%{winner} beat %{loser}"
+
+  views:
+    pagination:
+      first: "First"
+      last: "Last"
+      previous: "Prev"
+      next: "Next"
+      truncate: "&hellip;"

--- a/test/integration/result_pagination_test.rb
+++ b/test/integration/result_pagination_test.rb
@@ -1,0 +1,32 @@
+require 'integration_test_helper'
+
+class RankingPaginationTest < CapybaraTestCase
+
+  test "results are split between several pages" do
+    assume_a_trusted_user
+
+    submit_result("Carol", "Alice")
+    submit_result("Bob", "Dan")
+    submit_result("Bob", "Erin")
+    submit_result("Alice", "Bob")
+
+    visit '/results?per_page=3'
+
+    assert page.has_content?("Alice beat Bob")
+    assert page.has_content?("Bob beat Erin")
+    assert page.has_content?("Bob beat Dan")
+
+    assert page.has_no_content?("Carol beat Alice")
+
+    click_on "Next"
+
+    assert page.has_content?("Carol beat Alice")
+
+    click_on "Prev"
+
+    assert page.has_no_content?("Carol beat Alice")
+
+    assert page.has_content?("Alice beat Bob")
+  end
+
+end


### PR DESCRIPTION
## WHAT?

The results page can be slow to load, because it's loading every result ever. I've changed this to paginate instead.
## HOW?

I've used [kaminari](https://github.com/amatsuda/kaminari) for the pagination. The controls are fairly basic, but functional (fits in with the rest of the site?). It uses the (kaminari) default page size of 25 models. Looks like this:

![screen shot 2014-02-05 at 10 48 40 pm](https://f.cloud.github.com/assets/111963/2093354/b8a2263a-8eb7-11e3-841c-81a0286b2273.png)

There's an integration test to go with it as well.
