### PR TITLE
Ensure correct ordering of sparkline graph

### DIFF
--- a/app/helpers/players_helper.rb
+++ b/app/helpers/players_helper.rb
@@ -28,7 +28,7 @@ module PlayersHelper
   end
 
   def last_month_results
-    Result.where('created_at > ?', 1.month.ago)
+    Result.where('created_at > ?', 1.month.ago).order('created_at ASC')
   end
 
   def last_month_scores_by_user

--- a/app/helpers/players_helper.rb
+++ b/app/helpers/players_helper.rb
@@ -21,12 +21,6 @@ module PlayersHelper
 
   private
 
-  def previous_scores
-    @previous_scores ||= Result.all.flat_map { |result|
-      result.previous_state.fetch('elo_ratings', {}).values.compact
-    }
-  end
-
   def last_month_results
     Result.where('created_at > ?', 1.month.ago).order('created_at ASC')
   end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -34,15 +34,6 @@ class Result < ActiveRecord::Base
     loser.try(:name)
   end
 
-  def winner_new_position
-    winner.try(:position)
-  end
-
-  def loser_new_position
-    loser.try(:position)
-  end
-
-
   private
 
   def winner_different_from_loser

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -43,8 +43,8 @@ class Result < ActiveRecord::Base
   end
 
   def set_current_scores
-    self.winner_current_score = winner.elo_rating
-    self.loser_current_score = loser.elo_rating
+    self.winner_current_score = winner.reload.elo_rating
+    self.loser_current_score = loser.reload.elo_rating
   end
 
 end


### PR DESCRIPTION
Sroop's graph especially is looking crazy because of her meteoric rise over the last month. This should fix the ordering.

![screenshot 2015-03-10 17 20 47](https://cloud.githubusercontent.com/assets/45162/6580616/d4536c6a-c749-11e4-8d71-29ad0295cc1b.png)

Plus other tiny cleanup.