### PR TITLE
Update the layout to make better use of the iPad.

### DIFF
--- a/app/assets/javascripts/sparklines.js.coffee
+++ b/app/assets/javascripts/sparklines.js.coffee
@@ -2,7 +2,7 @@ run = ->
   min = $('[data-min]').data('min')
   max = $('[data-max]').data('max')
   height = $('.rankings-entry').height()/2
-  $('.sparkline').peity('line', {min, max, height, width: 100})
+  $('.sparkline').peity('line', {min, max, height, width: 200})
 
 jQuery(run)
 $(document).on('page:load', run)

--- a/app/assets/modules/rankings.css.scss
+++ b/app/assets/modules/rankings.css.scss
@@ -7,7 +7,6 @@
     border-bottom: 1px solid #ccc;
     line-height: 3em;
     list-style: none;
-    text-align: center;
   }
   .rankings-position {
     position: absolute;
@@ -15,6 +14,9 @@
     font-size: 2em;
     font-family: Georgia, sans-serif;
     color: $color-text-subdued;
+  }
+  .rankings-name {
+    margin-left: 8em;
   }
   .rankings-elo {
     display: block;

--- a/app/assets/stylesheets/mixins/dimensions.scss
+++ b/app/assets/stylesheets/mixins/dimensions.scss
@@ -1,1 +1,1 @@
-$desktop-max-width: 30em;
+$desktop-max-width: 48em;


### PR DESCRIPTION
I've tweaked the layout to make better use of the extra width the iPad affords us. Left aligned the names and made the Sparklines wider.

![screen shot 2015-05-18 at 17 10 22](https://cloud.githubusercontent.com/assets/165531/7684800/da0e61ce-fd80-11e4-9c88-76b82c5e86c7.png)
